### PR TITLE
cleaner way to fix table without needing to convert it to HTML

### DIFF
--- a/_posts/2025-02-26-3200p-cpu-util.md
+++ b/_posts/2025-02-26-3200p-cpu-util.md
@@ -601,91 +601,23 @@ If this claim is true, I expect it to only reproduce in
 Java, Kotlin, C#, Ruby, Typescript, and Python.
 I expect to not be able to reproduce the problem in Go, C++, Rust, and Elixir.
 
-<div style="overflow-x: scroll;">
-<table>
-  <thead>
-    <tr>
-      <th>Language</th>
-      <th>Affected</th>
-      <th>Explanation</th>
-      <th>Code</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Java</td>
-      <td>yes</td>
-      <td>this whole article is based on this</td>
-      <td><a href="https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/java/">source</a></td>
-    </tr>
-    <tr>
-      <td>C#</td>
-      <td>yes</td>
-      <td><a href="https://stackoverflow.com/questions/14909853/is-sorteddictionary-a-red-black-tree">SortedDictionary</a> used red black tree</td>
-      <td><a href="https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/csharp/">source</a></td>
-    </tr>
-    <tr>
-      <td>Ruby</td>
-      <td>no</td>
-      <td>Used red black tree from <a href="http://kanwei.github.io/algorithms/classes/Containers/RubyRBTreeMap.html">kanwei/algorithms</a> but was unable to reproduce the issue. I believe it might not be able to reproduce the problem due to the Global Interpreter Lock (GIL), and how it limits when threads can context switch preventing interleavings of threads that cause an infinite loop.</td>
-      <td><a href="https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/ruby/">source</a></td>
-    </tr>
-    <tr>
-      <td>C++</td>
-      <td>yes</td>
-      <td><a href="https://stackoverflow.com/questions/18414579/what-data-structure-is-inside-stdmap-in-c">used red-black tree</a>. I was expecting it to always segfault first preventing it from hitting the issue.</td>
-      <td><a href="https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/cpp/">source</a></td>
-    </tr>
-    <tr>
-      <td>Go</td>
-      <td>yes</td>
-      <td><a href="https://github.com/emirpasic/gods#redblacktree">has popular datastructures library</a>. Similar to C++, I was expecting it only segfault and not reproduce the infinite loop. I was wrong.</td>
-      <td><a href="https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/golang/">source</a></td>
-    </tr>
-    <tr>
-      <td>Rust</td>
-      <td>no</td>
-      <td>compiler prevented me. I don't know enough about writing unsafe code to reproduce the problem</td>
-      <td><a href="https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/rust/">source</a></td>
-    </tr>
-    <tr>
-      <td>Kotlin</td>
-      <td>yes</td>
-      <td>uses java's TreeMap, same issue expected</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>PHP</td>
-      <td>no</td>
-      <td>not in standard library and did not find any popular libraries with red black tree</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>JavaScript</td>
-      <td>no</td>
-      <td><a href="https://stackoverflow.com/questions/40028377/is-it-possible-to-achieve-multithreading-in-nodejs">multithreading model cannot share references</a></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Typescript</td>
-      <td>no</td>
-      <td>same argument as JavaScript</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Python</td>
-      <td>no</td>
-      <td>no red-black tree in standard library and popular libraries like <a href="https://grantjenks.com/docs/sortedcontainers/implementation.html">Sorted Containers do not use red black tree</a>. despite no red black tree, if I had run the experiment, I would expect to not to be able to reproduce for the same reason as ruby: the GIL.</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Elixir</td>
-      <td>no</td>
-      <td>Although there are many third party implementations of the red black trees in Elixir (and Erlang), the programming model makes it impossible: data structures are immutable and interactions between threads are limited to message passing.</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+<div style="overflow-x: scroll;" markdown="1">
+
+| Language   | Affected | Explanation | Code |
+|------------|----------|-------------|------|
+| Java       | yes      | this whole article is based on this | [source](https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/java/) |
+| C#         | yes      | [SortedDictionary](https://stackoverflow.com/questions/14909853/is-sorteddictionary-a-red-black-tree) used red black tree | [source](https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/csharp/) |
+| Ruby       | no       | Used red black tree from [kanwei/algorithms](http://kanwei.github.io/algorithms/classes/Containers/RubyRBTreeMap.html) but was unable to reproduce the issue. I believe it might not be able to reproduce the problem due to the Global Interpreter Lock (GIL), and how it limits when threads can context switch preventing interleavings of threads that cause an infinite loop.     | [source](https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/ruby/) |
+| C++        | yes      | [used red-black tree](https://stackoverflow.com/questions/18414579/what-data-structure-is-inside-stdmap-in-c). I was expecting it to always segfault first preventing it from hitting the issue. | [source](https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/cpp/) |
+| Go         | yes      | [has popular datastructures library](https://github.com/emirpasic/gods#redblacktree). Similar to C++, I was expecting it only segfault and not reproduce the infinite loop. I was wrong.      | [source](https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/golang/) |
+| Rust       | no       | compiler prevented me. I don't know enough about writing unsafe code to reproduce the problem | [source](https://github.com/josephmate/java-by-experiments/tree/main/tree_map_corruption/rust/) |
+| Kotlin     | yes      | uses java's TreeMap, same issue expected     |  |
+| PHP        | no       | not in standard library and did not find any popular libraries with red black tree  | |
+| JavaScript  | no       | [multithreading model cannot share references](https://stackoverflow.com/questions/40028377/is-it-possible-to-achieve-multithreading-in-nodejs) | |
+| Typescript | no       | same argument as JavaScript | |
+| Python     | no       | no red-black tree in standard library and popular libraries like [Sorted Containers do not use red black tree](https://grantjenks.com/docs/sortedcontainers/implementation.html). despite no red black tree, if I had run the experiment, I would expect to not to be able to reproduce for the same reason as ruby: the GIL. | |
+| Elixir     | no       | Although there are many third party implementations of the red black trees in Elixir (and Erlang), the programming model makes it impossible: data structures are immutable and interactions between threads are limited to message passing. |  |
+
 </div>
 
 From the table, the most interesting one is C++ because I was not expecting to be able to reproduce the problem due to my hypothesis from the last section.


### PR DESCRIPTION
I already fixed it in beautifuljekyll, so if you want to live on the edge and change your config to use the dev version instead of being pegged to a specific version, you can go back to using your pure markdown table.

But assuming you're a boring, safe, living-in-the-burbs, father-of-two, you might not want to do that. You can still keep the markdown table without converting it to HTML, and you can still wrap it inside a div using this technique